### PR TITLE
chore: go-demo-6 to 2.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: go-demo-6
   repository: http://jenkins-x-chartmuseum:8080
-  version: 2.0.2
+  version: 2.0.4
 - name: jx-go
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1


### PR DESCRIPTION
chore: Promote go-demo-6 to version 2.0.4